### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.4.0
+
+### Features
+- feat(tags): UUID support for tag IDs with multi-endpoint fallback and improved error messages
+- feat(mcp): Numeric workflow ID aliases (numericId) accepted across all workflow operations
+- docs: Implementation summary and endpoint compatibility documentation added
+- dev: Docker compose devcontainer with bundled n8n sidecar for faster E2E
+
+### Fixes & Improvements
+- fix(tags): Normalize tag operation error messages and robust PUT fallback
+- fix(client): Guard axios interceptor attachment in mocked test environments
+- test: Expanded smoke tests (CLI + MCP stdio) and output helper coverage
+- chore(ci): Add opencode slash-command workflow for on-demand coding agent runs
+- deps: Bump @modelcontextprotocol/sdk, dotenv, @types/node, typescript
+
+### Notes
+Enhanced tag and workflow ID ergonomics plus sturdier integration tests improve reliability and developer experience.
+
 ## v0.3.0
 
 - feat: Add end-to-end CLI smoke tests against real n8n

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get2knowio/n8n-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server for n8n workflow management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/release-notes/v0.4.0.md
+++ b/scripts/release-notes/v0.4.0.md
@@ -1,0 +1,13 @@
+# v0.4.0
+
+- Tag UUID support with multi-endpoint fallback and clearer errors
+- Numeric workflow ID aliases (numericId) accepted across all MCP tools
+- Expanded smoke + output tests; guarded axios interceptors in tests
+- Devcontainer now includes docker compose with n8n sidecar
+- Added implementation summary & endpoint compatibility docs
+- Added opencode slash-command CI workflow
+- Dependency bumps: @modelcontextprotocol/sdk, dotenv, @types/node, typescript
+
+Publish to npm and verify:
+- Install: `npm install @get2knowio/n8n-mcp@0.4.0`
+- ESM import works and CLI `n8n-mcp --help` shows new version


### PR DESCRIPTION
# v0.4.0

- Tag UUID support with multi-endpoint fallback and clearer errors
- Numeric workflow ID aliases (numericId) accepted across all MCP tools
- Expanded smoke + output tests; guarded axios interceptors in tests
- Devcontainer now includes docker compose with n8n sidecar
- Added implementation summary & endpoint compatibility docs
- Added opencode slash-command CI workflow
- Dependency bumps: @modelcontextprotocol/sdk, dotenv, @types/node, typescript

Publish to npm and verify:
- Install: `npm install @get2knowio/n8n-mcp@0.4.0`
- ESM import works and CLI `n8n-mcp --help` shows new version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support UUIDs for tag IDs with multi-endpoint fallback and clearer error messages
  - Accept numeric workflow ID aliases across workflow operations

- Bug Fixes
  - Normalized tag operation errors and added robust PUT fallback
  - Prevented duplicate interceptor attachment in mocked test environments

- Documentation
  - Added implementation summary and endpoint compatibility details

- Tests
  - Expanded smoke tests (CLI and MCP stdio) and output helper coverage

- Chores
  - Bumped dependencies and tooling; added on-demand CI workflow
  - Version bumped to 0.4.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->