### PR TITLE
chore: enforce 7-day supply-chain cooldown on dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
+    # Supply-chain cooldown: hold newly published versions for 7 days so a
+    # compromised release can be detected/yanked before it's proposed. The
+    # first-party @get2knowio/* scope is exempt.
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@get2knowio/*"
     reviewers:
       - "pofallon"
     assignees:
@@ -27,6 +34,8 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     reviewers:
       - "pofallon"
     assignees:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Supply-chain cooldown: refuse versions published less than 7 days ago so a
+# malicious release has time to be detected/yanked before install. npm has no
+# per-package exclusion, so this applies to all deps.
+min-release-age=7


### PR DESCRIPTION
## Supply-chain cooldown (7-day minimum release age)

Part of an org-wide rollout hardening get2knowio repos against supply-chain attacks. A newly published dependency version must age **7 days** before it can be installed/resolved or proposed by Dependabot — giving time for a malicious release to be detected and yanked. Security updates are never delayed (Dependabot cooldown applies to *version* updates only).

Config schema verified against current official docs (not training data).

### Changes
- **npm (`.npmrc`)** — created with `min-release-age=7`.
- **Dependabot** — `cooldown: { default-days: 7 }` on `npm` (excludes first-party `@get2knowio/*`) and `github-actions`.

Note: this package is `@get2knowio/n8n-mcp`; npm PM layer cannot exempt first-party (no exclusion key), but it has no self-dependency so this is moot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 7-day cooldown requirement for dependency updates, ensuring packages must be published at least 7 days before adoption across npm and GitHub Actions ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->