### PR TITLE
feat(http): add Streamable HTTP transport alongside stdio

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,10 +89,10 @@ npm ci          # Clean install (CI uses this, not npm install)
 npm run lint    # TypeScript type checking
 npm run build   # Build project
 npm run test    # Run test suite
-npm run test:coverage  # Produce coverage/lcov.info (uploaded to Coveralls in CI)
+npm run test:coverage  # Produce coverage/lcov.info and enforce jest.config.js thresholds
 ```
 
-**CI Pipeline Requirements**: The project tests against Node.js versions 18.x, 20.x, and 22.x. Current development uses Node.js v20.19.4. Coverage is uploaded to Coveralls (parallel uploads with a finalize step).
+**CI Pipeline Requirements**: The project tests against Node.js versions 18.x, 20.x, and 22.x. Current development uses Node.js v20.19.4. Coverage is collected via `npm run test:coverage` and enforced against the thresholds in `jest.config.js`.
 
 ## Pull Request Hygiene: Auto-close Issues
 
@@ -204,7 +204,7 @@ Release notes formatting rules:
 - Example body:
 	- Publish to npm
 	- Post-publish verify (install, ESM import, CLI)
-	- CI: Coveralls coverage upload (parallel + finalize)
+	- CI: lint, tests, and coverage across Node 18/20/22
 
 ## Troubleshooting
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,23 +31,3 @@ jobs:
     
     - name: Run tests with coverage
       run: npm run test:coverage
-
-    - name: Upload coverage to Coveralls (parallel)
-      uses: coverallsapp/github-action@v2
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./coverage/lcov.info
-        flag-name: node-${{ matrix.node-version }}
-        parallel: true
-
-
-  coveralls_finish:
-    name: Coveralls Finish
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Finalize parallel coverage
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -139,6 +139,52 @@ npx @get2knowio/n8n-mcp
 
 This starts the MCP server on stdio for integration with AI agents. Configure access via environment variables (see Configuration).
 
+#### Streamable HTTP transport
+
+Instead of stdio, the same server can run as a long-lived **HTTP** service (MCP
+Streamable HTTP transport) — useful for hosting it behind a reverse proxy or sharing it
+across clients:
+
+```bash
+# Start the HTTP server (flag or env)
+n8n-mcp --http
+# equivalently:
+MCP_TRANSPORT=http n8n-mcp
+```
+
+It is **single-tenant**: every session uses the same `N8N_BASE_URL` / `N8N_API_KEY` (or
+basic-auth) from the environment, exactly like the stdio server.
+
+HTTP-specific configuration (all optional):
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MCP_HTTP_PORT` (or `PORT`) | `3000` | Port to bind. |
+| `MCP_HTTP_HOST` | `127.0.0.1` | Interface to bind. **Loopback by default** — set to `0.0.0.0` to expose. |
+| `MCP_HTTP_PATH` | `/mcp` | MCP endpoint path. |
+| `MCP_HTTP_TOKEN` | _(unset)_ | When set, every request must send `Authorization: Bearer <token>`. When unset, **no auth is enforced** — only safe on a trusted loopback/network. |
+
+Endpoints: the MCP endpoint is `POST/GET/DELETE <MCP_HTTP_PATH>` (Streamable HTTP, JSON
+responses, `mcp-session-id` header per session). A `GET /healthz` liveness probe returns
+`{"ok":true}` and is intentionally unauthenticated.
+
+> ⚠️ The default bind is loopback and there is no auth unless you set `MCP_HTTP_TOKEN`.
+> Before exposing the port (`MCP_HTTP_HOST=0.0.0.0` or via a proxy), set a token.
+
+Example MCP client config (HTTP):
+
+```json
+{
+  "servers": {
+    "n8n": {
+      "type": "http",
+      "url": "http://127.0.0.1:3000/mcp",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" }
+    }
+  }
+}
+```
+
 ### 2) As a CLI Tool
 
 The CLI binary is `n8n-mcp`. After a global install:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI/CD](https://github.com/get2knowio/n8n-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/get2knowio/n8n-mcp/actions/workflows/ci.yml)
 [![Release](https://github.com/get2knowio/n8n-mcp/actions/workflows/release.yml/badge.svg)](https://github.com/get2knowio/n8n-mcp/actions/workflows/release.yml)
-[![Coverage Status](https://coveralls.io/repos/github/get2knowio/n8n-mcp/badge.svg?branch=main)](https://coveralls.io/github/get2knowio/n8n-mcp?branch=main)
 [![npm version](https://img.shields.io/npm/v/@get2knowio/n8n-mcp.svg)](https://www.npmjs.com/package/@get2knowio/n8n-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -779,7 +778,7 @@ This triggers the Release workflow which builds, tests, publishes to npm, and th
 
 ## Coverage Reporting
 
-Coverage is collected with Jest and uploaded in CI via Coveralls. See [CONTRIBUTING.md](./CONTRIBUTING.md) for local coverage commands.
+Coverage is collected with Jest and enforced against the thresholds in `jest.config.js` (CI runs `npm run test:coverage`). See [CONTRIBUTING.md](./CONTRIBUTING.md) for local coverage commands.
 
 To create a new release:
 1. Update the version in `package.json`

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "start": "node dist/index.js",
+    "start": "node dist/main.js",
+    "start:http": "node dist/main.js --http",
     "cli": "node dist/cli.js",
     "smoke": "node scripts/smoke/smoke.js",
     "test": "jest",

--- a/scripts/smoke/smoke.js
+++ b/scripts/smoke/smoke.js
@@ -51,7 +51,7 @@ process.env.MCP_ENABLE_SOURCE_MAPS = process.env.MCP_ENABLE_SOURCE_MAPS || '1';
 process.env.MCP_DEBUG = process.env.MCP_DEBUG || 'debug';
 
 const CLI = resolve(__dirname, '../../dist/cli.js');
-const MCP_SERVER = resolve(__dirname, '../../dist/index.js');
+const MCP_SERVER = resolve(__dirname, '../../dist/main.js');
 const EXAMPLE_WORKFLOW = resolve(__dirname, '../../examples/example-workflow.json');
 
 async function runCli(args, { timeoutMs = 20000 } = {}) {

--- a/src/__tests__/http-server.test.ts
+++ b/src/__tests__/http-server.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, jest, beforeAll, afterAll } from '@jest/globals';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+// Only the n8n client is mocked so no real n8n is contacted. The SDK server and the
+// StreamableHTTP transport are the real thing — this exercises a genuine HTTP round trip.
+jest.mock('../n8n-client.js', () => ({
+  N8nClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+import { startHttpServer } from '../http-server.js';
+
+const TOKEN = 'test-secret-token';
+const ACCEPT = 'application/json, text/event-stream';
+
+describe('startHttpServer (Streamable HTTP transport)', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.N8N_BASE_URL = 'http://test-n8n.local:5678';
+    process.env.N8N_API_KEY = 'test-api-key';
+    server = await startHttpServer({ port: 0, host: '127.0.0.1', token: TOKEN });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  });
+
+  const initializeBody = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'jest', version: '0.0.0' },
+    },
+  };
+
+  it('serves /healthz without auth', async () => {
+    const res = await fetch(`${baseUrl}/healthz`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it('rejects an MCP request with no bearer token', async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: ACCEPT },
+      body: JSON.stringify(initializeBody),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('initializes a session and lists tools over one session', async () => {
+    // initialize -> expect a session id header and a valid result
+    const initRes = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: ACCEPT, Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify(initializeBody),
+    });
+    expect(initRes.status).toBe(200);
+    const sessionId = initRes.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+    const initJson: any = await initRes.json();
+    expect(initJson.result?.serverInfo?.name).toBe('n8n-mcp');
+
+    // required lifecycle step before issuing further requests
+    const notifyRes = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: ACCEPT,
+        Authorization: `Bearer ${TOKEN}`,
+        'mcp-session-id': sessionId!,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+    });
+    expect(notifyRes.status).toBeLessThan(300);
+
+    // tools/list reuses the session — static list, no n8n call
+    const listRes = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: ACCEPT,
+        Authorization: `Bearer ${TOKEN}`,
+        'mcp-session-id': sessionId!,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+    });
+    expect(listRes.status).toBe(200);
+    const listJson: any = await listRes.json();
+    expect(Array.isArray(listJson.result?.tools)).toBe(true);
+    expect(listJson.result.tools.length).toBeGreaterThan(0);
+    expect(listJson.result.tools.some((t: any) => t.name === 'health_check')).toBe(true);
+  });
+
+  it('rejects a non-initialize request with no session id', async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: ACCEPT, Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,170 @@
+import http from 'node:http';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { N8nMcpServer } from './index.js';
+import { logger } from './logger.js';
+
+export interface HttpServerOptions {
+  /** Port to bind. Falls back to MCP_HTTP_PORT, then PORT, then 3000. */
+  port?: number;
+  /** Host/interface to bind. Falls back to MCP_HTTP_HOST, then 127.0.0.1 (loopback). */
+  host?: string;
+  /** MCP endpoint path. Falls back to MCP_HTTP_PATH, then /mcp. */
+  path?: string;
+  /** Optional bearer token. Falls back to MCP_HTTP_TOKEN. When unset, no auth is enforced. */
+  token?: string;
+}
+
+interface Session {
+  transport: StreamableHTTPServerTransport;
+  server: N8nMcpServer;
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c as Buffer));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function tokenMatches(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  // timingSafeEqual requires equal-length buffers; the length check itself is not
+  // constant-time, but the token length is not the secret.
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * Start the n8n MCP server over the Streamable HTTP transport.
+ *
+ * Single-tenant: every session's N8nMcpServer reads the same N8N_* env config.
+ * Sessions are stateful — each gets its own N8nMcpServer instance (and thus its own
+ * SDK Server + workflow-id alias maps), so per-client state stays isolated.
+ */
+export async function startHttpServer(options: HttpServerOptions = {}): Promise<http.Server> {
+  const port = options.port ?? Number(process.env.MCP_HTTP_PORT ?? process.env.PORT ?? 3000);
+  const host = options.host ?? process.env.MCP_HTTP_HOST ?? '127.0.0.1';
+  const mcpPath = options.path ?? process.env.MCP_HTTP_PATH ?? '/mcp';
+  const token = options.token ?? process.env.MCP_HTTP_TOKEN;
+
+  const sessions = new Map<string, Session>();
+
+  const authorized = (req: http.IncomingMessage): boolean => {
+    if (!token) return true;
+    const header = req.headers['authorization'];
+    if (!header || Array.isArray(header)) return false;
+    const match = /^Bearer (.+)$/.exec(header);
+    return match ? tokenMatches(match[1], token) : false;
+  };
+
+  const httpServer = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || '/', `http://${req.headers.host ?? host}`);
+
+      // Liveness/preflight — intentionally unauthenticated.
+      if (req.method === 'GET' && url.pathname === '/healthz') {
+        sendJson(res, 200, { ok: true });
+        return;
+      }
+
+      if (url.pathname !== mcpPath) {
+        sendJson(res, 404, { error: 'not found' });
+        return;
+      }
+
+      if (!authorized(req)) {
+        sendJson(res, 401, { jsonrpc: '2.0', error: { code: -32001, message: 'Unauthorized' }, id: null });
+        return;
+      }
+
+      const sessionIdHeader = req.headers['mcp-session-id'];
+      const sessionId = typeof sessionIdHeader === 'string' ? sessionIdHeader : undefined;
+      const existing = sessionId ? sessions.get(sessionId) : undefined;
+
+      if (req.method === 'POST') {
+        const raw = await readBody(req);
+        let body: unknown;
+        try {
+          body = raw ? JSON.parse(raw) : undefined;
+        } catch {
+          sendJson(res, 400, { jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null });
+          return;
+        }
+
+        let transport: StreamableHTTPServerTransport;
+        if (existing) {
+          transport = existing.transport;
+        } else if (!sessionId && isInitializeRequest(body)) {
+          const server = new N8nMcpServer();
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            // Respond with plain JSON rather than an SSE stream — every tool here is a
+            // simple request/response, and JSON is friendlier to curl/fetch clients.
+            enableJsonResponse: true,
+            onsessioninitialized: (id) => {
+              sessions.set(id, { transport, server });
+              logger.info('MCP HTTP session initialized', { sessionId: id, sessions: sessions.size });
+            },
+            onsessionclosed: (id) => {
+              sessions.delete(id);
+              logger.info('MCP HTTP session closed', { sessionId: id, sessions: sessions.size });
+            },
+          });
+          transport.onclose = () => {
+            if (transport.sessionId) sessions.delete(transport.sessionId);
+          };
+          await server.connect(transport);
+        } else {
+          sendJson(res, 400, {
+            jsonrpc: '2.0',
+            error: { code: -32000, message: 'Bad Request: no valid session ID for a non-initialize request' },
+            id: null,
+          });
+          return;
+        }
+
+        await transport.handleRequest(req, res, body);
+        return;
+      }
+
+      // GET (SSE stream) and DELETE (session teardown) require an established session.
+      if (req.method === 'GET' || req.method === 'DELETE') {
+        if (!existing) {
+          sendJson(res, 404, { jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null });
+          return;
+        }
+        await existing.transport.handleRequest(req, res);
+        return;
+      }
+
+      res.writeHead(405, { 'Content-Type': 'application/json', Allow: 'GET, POST, DELETE' });
+      res.end(JSON.stringify({ error: 'method not allowed' }));
+    } catch (err) {
+      logger.error('MCP HTTP request failed', { error: err instanceof Error ? err.message : String(err) });
+      if (!res.headersSent) {
+        sendJson(res, 500, { jsonrpc: '2.0', error: { code: -32603, message: 'Internal server error' }, id: null });
+      }
+    }
+  });
+
+  await new Promise<void>((resolve) => httpServer.listen(port, host, resolve));
+  const address = httpServer.address();
+  const boundPort = typeof address === 'object' && address ? address.port : port;
+  logger.info('N8n MCP server running on Streamable HTTP', {
+    host,
+    port: boundPort,
+    path: mcpPath,
+    authRequired: !!token,
+  });
+  return httpServer;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { N8nClient } from './n8n-client.js';
 import { logger, newCorrelationId, getLogLevel } from './logger.js';
@@ -815,15 +816,20 @@ export class N8nMcpServer {
     return { content: [{ type: 'text', text: JSON.stringify(jsonSuccess(result), null, 2) }] };
   }
 
-  async run() {
-    const transport = new StdioServerTransport();
+  /**
+   * Connect this server to an arbitrary MCP transport (stdio, Streamable HTTP, …).
+   * Each connected transport should be paired with its own N8nMcpServer instance so
+   * per-instance state (workflow id aliases) stays isolated per client session.
+   */
+  async connect(transport: Transport) {
     await this.server.connect(transport);
+  }
+
+  async run() {
+    await this.connect(new StdioServerTransport());
     logger.info('N8n MCP server running on stdio');
   }
 }
 
-const server = new N8nMcpServer();
-server.run().catch((error) => {
-  logger.error('Server failed', { error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined });
-  process.exit(1);
-});
+// Note: this module has no side effects on import — it is a library. The stdio server
+// is started from the `main.ts` entrypoint (or `cli.ts` when invoked with no args).

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
 
 // Unified entrypoint to support both VS Code "NPM Package" flow and CLI usage.
+// - With `--http` (or MCP_TRANSPORT=http): start the Streamable HTTP MCP server
 // - If invoked without args: start MCP stdio server
 // - If invoked with args: treat as CLI (same as n8n-mcp)
 
 async function run() {
   const args = process.argv.slice(2);
+
+  if (args.includes('--http') || process.env.MCP_TRANSPORT === 'http') {
+    const { startHttpServer } = await import('./http-server.js');
+    await startHttpServer();
+    return;
+  }
+
   if (args.length === 0) {
     const { N8nMcpServer } = await import('./index.js');
     const server = new N8nMcpServer();


### PR DESCRIPTION
## What

Two things:

1. **Adds an HTTP (Streamable HTTP) transport** so the n8n MCP server can run as a long-lived service, not only spawned per-client over stdio. Stdio is unchanged.
2. **Removes the Coveralls coverage upload from CI** (recurring flaky-red during Coveralls outages). Coverage is still collected and enforced via `npm run test:coverage` against the `jest.config.js` thresholds — only the external upload is gone.

```bash
n8n-mcp --http           # or: MCP_TRANSPORT=http n8n-mcp
```

## How (HTTP transport)

- **Transport-agnostic server** — new `N8nMcpServer.connect(transport)`; `run()` now delegates to it (still stdio). No new runtime dependency: the SDK's `StreamableHTTPServerTransport` already bundles `@hono/node-server`, so the HTTP host is plain `node:http` — no express.
- **`src/http-server.ts`** — stateful sessions, **one `N8nMcpServer` per session** so the per-instance workflow-id alias maps stay isolated across clients. **Single-tenant**: every session uses the same `N8N_*` env config, exactly like stdio.
- **Optional auth** — `MCP_HTTP_TOKEN` gates the endpoint with `Authorization: Bearer` (constant-time compare); off by default. Binds `127.0.0.1` by default; `GET /healthz` is an unauthenticated liveness probe.
- **Entrypoint cleanup** — `index.ts` is now a pure library (dropped the import-time auto-run that also caused a latent double-start); `main.ts` is the single entrypoint and selects the transport. `start` script + smoke harness now point at `dist/main.js`; added `start:http`.

### Config (all optional)

| Variable | Default | Description |
| --- | --- | --- |
| `MCP_HTTP_PORT` / `PORT` | `3000` | Port |
| `MCP_HTTP_HOST` | `127.0.0.1` | Bind interface (loopback by default) |
| `MCP_HTTP_PATH` | `/mcp` | Endpoint path |
| `MCP_HTTP_TOKEN` | _(unset)_ | Bearer token; no auth when unset |

## Testing

- New `src/__tests__/http-server.test.ts` drives a **real HTTP round trip** (initialize → `notifications/initialized` → `tools/list`) against the actual SDK transport, plus the 401 auth gate and the no-session 400 path.
- Full suite green (**251 tests**), `tsc --noEmit` + `build` clean.
- Manual curl round trip against the built `dist/main.js --http`: `healthz` 200, unauth 401, session init, `tools/list` returns 49 tools incl. `health_check`.

## Out of scope

Multi-tenant / per-request n8n credentials (single-tenant chosen) and a Dockerfile — noted as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an HTTP transport mode for the MCP server (with session-based handling, health check, and tool access).
* **Documentation**
  * Updated README with HTTP endpoint patterns, session header usage, configuration options, and security guidance.
  * Adjusted coverage messaging and removed the Coveralls badge.
* **Bug Fixes**
  * Updated startup and smoke tests to use the correct server entrypoint.
* **Tests / CI**
  * Added an HTTP integration test suite.
  * Updated CI to run coverage via Jest thresholds (`npm run test:coverage`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->